### PR TITLE
asApp fluent method for overriding app for next request

### DIFF
--- a/src/timekit.js
+++ b/src/timekit.js
@@ -61,7 +61,6 @@ function Timekit() {
    */
   var TK = {};
 
-
   /**
    * Prepare and make HTTP request to API
    * @type {Object}
@@ -74,7 +73,8 @@ function Timekit() {
 
     // add http headers if applicable
     args.headers = args.headers || headers || {};
-    args.headers['Timekit-App'] = config.app;
+
+    if (!args.headers['Timekit-App']) args.headers['Timekit-App'] = config.app;
     if (config.inputTimestampFormat) { args.headers['Timekit-InputTimestampFormat'] = config.inputTimestampFormat; }
     if (config.outputTimestampFormat) { args.headers['Timekit-OutputTimestampFormat'] = config.outputTimestampFormat; }
     if (config.timezone) { args.headers['Timekit-Timezone'] = config.timezone; }
@@ -150,15 +150,6 @@ function Timekit() {
   };
 
   /**
-   * Set the active user temporarily for the next request (fluent/chainable return)
-   * @type {Function}
-   */
-  TK.asUser = function(email, apiToken) {
-    headers['Authorization'] = 'Basic ' + encodeAuthHeader(email, apiToken);
-    return this;
-  };
-
-  /**
    * Returns the current active user
    * @type {Function}
    * @return {Object}
@@ -168,6 +159,24 @@ function Timekit() {
       email: userEmail,
       apiToken: userToken
     };
+  };
+
+  /**
+   * Set the active user temporarily for the next request (fluent/chainable return)
+   * @type {Function}
+   */
+  TK.asUser = function(email, apiToken) {
+    headers['Authorization'] = 'Basic ' + encodeAuthHeader(email, apiToken);
+    return this;
+  };
+
+  /**
+  * Set the timekit app slug temporarily for the next request (fluent/chainable return)
+  * @type {Function}
+  */
+  TK.asApp = function(slug) {
+    headers['Timekit-App'] = slug;
+    return this;
   };
 
   /**
@@ -186,7 +195,7 @@ function Timekit() {
    * @return {Object}
    */
   TK.headers = function(data) {
-    headers = data;
+    for (var attr in data) { headers[attr] = data[attr]; }
     return this;
   };
 


### PR DESCRIPTION
Same as `asUser`, but just for the `Timekit-App` request header. Useful when switching context between apps frequently.

@vistik 