### PR TITLE
Optional response flattening (and save metadata)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ timekit.configure({
     outputTimestampFormat:      'Y-m-d h:ia',               // default timestamp format that you want the API to return
     timezone:                   'Europe/Copenhagen',        // override user's timezone for custom formatted timestamps in another timezone
     convertResponseToCamelcase: false,                      // should keys in JSON response automatically be converted from snake_case to camelCase?
-    convertRequestToSnakecase:  true                        // should keys in JSON requests automatically be converted from camelCase to snake_case?
+    convertRequestToSnakecase:  true,                       // should keys in JSON requests automatically be converted from camelCase to snake_case?
+    autoFlattenResponse: true                               // if you keep this set to true, then responses with a "data" key will automatically be flattened to response.data (otherwise you need to access response.data.data). Note that pagination meta data is lost though.
 });
 
 // Returns current config object

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/timekit/js-sdk.git"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "./node_modules/karma/bin/karma start",
+    "build": "webpack && webpack --config webpack.config.min.js"
   },
   "keywords": [
     "Timekit",
@@ -34,13 +35,13 @@
     "karma-jasmine": "^0.3.5",
     "karma-jasmine-ajax": "^0.1.12",
     "karma-jasmine-jquery": "^0.1.1",
-    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-spec-reporter": "0.0.19",
     "karma-webpack": "^1.7.0",
     "moment": "^2.10.3",
     "node-libs-browser": "^0.5.2",
-    "phantomjs": "^1.9.17",
+    "phantomjs": "^2.1.3",
     "webpack": "^1.11.0"
   },
   "dependencies": {

--- a/src/timekit.js
+++ b/src/timekit.js
@@ -104,7 +104,10 @@ function Timekit() {
     var interceptor = axios.interceptors.response.use(function (response) {
       if (response.data && response.data.data) {
         if (config.autoFlattenResponse) {
-          response.data = response.data.data;
+          var responseCopy = Object.assign({}, response);
+          response.data = responseCopy.data.data;
+          delete responseCopy.data.data;
+          response.metaData = responseCopy.data;
         }
         if (config.convertResponseToCamelcase) {
           response.data = humps.camelizeKeys(response.data);

--- a/src/timekit.js
+++ b/src/timekit.js
@@ -56,6 +56,14 @@ function Timekit() {
     return config.apiBaseUrl + config.apiVersion + endpoint;
   };
 
+  var copyResponseMetaData = function(response) {
+    if (Object.keys(response.data).length < 2) return
+    response.metaData = {}
+    Object.keys(response.data).forEach(function(key) {
+      if (key !== 'data') response.metaData[key] = response.data[key]
+    })
+  }
+
   /**
    * Root Object that holds methods to expose for API consumption
    * @type {Object}
@@ -104,10 +112,8 @@ function Timekit() {
     var interceptor = axios.interceptors.response.use(function (response) {
       if (response.data && response.data.data) {
         if (config.autoFlattenResponse) {
-          var responseCopy = Object.assign({}, response);
-          response.data = responseCopy.data.data;
-          delete responseCopy.data.data;
-          response.metaData = responseCopy.data;
+          copyResponseMetaData(response)
+          response.data = response.data.data;
         }
         if (config.convertResponseToCamelcase) {
           response.data = humps.camelizeKeys(response.data);

--- a/src/timekit.js
+++ b/src/timekit.js
@@ -33,7 +33,8 @@ function Timekit() {
     apiBaseUrl: 'https://api.timekit.io/',
     apiVersion: 'v2',
     convertResponseToCamelcase: false,
-    convertRequestToSnakecase: true
+    convertRequestToSnakecase: true,
+    autoFlattenResponse: true
   };
 
   /**
@@ -102,7 +103,9 @@ function Timekit() {
     // register response interceptor for data manipulation
     var interceptor = axios.interceptors.response.use(function (response) {
       if (response.data && response.data.data) {
-        response.data = response.data.data;
+        if (config.autoFlattenResponse) {
+          response.data = response.data.data;
+        }
         if (config.convertResponseToCamelcase) {
           response.data = humps.camelizeKeys(response.data);
         }

--- a/test/configuration.spec.js
+++ b/test/configuration.spec.js
@@ -20,7 +20,8 @@ var fixtures = {
       contactName: 'John Doe',
       contactEmail: 'john@doe.com'
     }
-  }
+  },
+  autoFlattenResponse: true
 }
 
 /**
@@ -336,6 +337,43 @@ describe('Configuration', function() {
             done();
           })
         });
+      });
+    });
+
+  });
+
+  it('should be able to flatten response data and maintain metaData', function(done) {
+    var response, request;
+
+    timekit.configure({
+      app: fixtures.app,
+      apiBaseUrl: fixtures.apiBaseUrl,
+      autoFlattenResponse: fixtures.autoFlattenResponse
+    });
+
+    timekit.setUser(fixtures.userEmail, fixtures.userApiToken);
+
+    timekit.getApps()
+    .then(function(res) {
+      response = res;
+    });
+
+    utils.tick(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      request.respondWith({
+        status: 201,
+        responseText: '{ "data": { "slug": "testapplication", "contact_email": "2312312312@timekit.io", "contact_name": "John Doe", "id": "k3FXhXOAvF0BcT2cpSbQUhp5kHZmHoEe", "settings": { "name": "TestApplication" } }, "other_meta_key": "other_meta_value" }'
+      });
+
+      utils.tick(function () {
+        // Response
+        expect(response.status).toBe(201);
+        expect(response.data).toBeDefined();
+        expect(typeof response.data.slug).toBe('string');
+        expect(response.metaData).toBeDefined();
+        expect(response.metaData.other_meta_key).toBe('other_meta_value');
+        done();
       });
     });
 


### PR DESCRIPTION
Motivation?
------------
We were adding pagination to the Timekit admin panel and we discovered that metadata (outside of `response.data`) were lost because the library ignorantly just copied `response.data.data` to `response.data`. 

Design choices?
------------
Makes it optional to have the response data "flattened", i.e. setting `response.data.data` to `response.data`, by setting `autoFlattenResponse = false`

If "flattening" is enabled (which it is by default), it however has the side-effect that meta data like pagination info that are not in the `data` key gets lost in the process. This PR adds a new key, `metaData`, that contains all other information not in `data`.

Tests?
------------
Made a test case to make sure that `metaData` is saved correctly.

Who should review it?
------------

@Trolzie 