### PR TITLE
Generate new fresh instance of library

### DIFF
--- a/src/timekit.js
+++ b/src/timekit.js
@@ -924,6 +924,15 @@ function Timekit() {
 
   };
 
+  /**
+   * Return a new instance of the SDK
+   * @type {Function}
+   * @return {Object}
+   */
+  TK.newInstance = function() {
+    return new Timekit();
+  }
+
   return TK;
 
 }

--- a/test/multipleInstances.spec.js
+++ b/test/multipleInstances.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var timekit = require('../src/timekit.js');
+var utils = require('./helpers/utils');
+var base64 = require('base-64');
+
+var fixtures = {
+  app:              'demo',
+  app2:             'demo2'
+}
+
+describe('Multiple instances', function() {
+
+  beforeEach(function() {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  it('should be able to create multiple isolated instances', function() {
+
+    var instance1 = timekit.newInstance();
+    var instance2 = timekit.newInstance();
+
+    instance1.configure({
+      app: fixtures.app
+    });
+
+    instance2.configure({
+      app: fixtures.app
+    });
+
+    var instance1App = instance1.getConfig().app;
+    var instance2App = instance2.getConfig().app;
+
+    expect(instance1App).not.toEqual(instance2App);
+
+  });
+
+});

--- a/test/multipleInstances.spec.js
+++ b/test/multipleInstances.spec.js
@@ -29,7 +29,7 @@ describe('Multiple instances', function() {
     });
 
     instance2.configure({
-      app: fixtures.app
+      app: fixtures.app2
     });
 
     var instance1App = instance1.getConfig().app;


### PR DESCRIPTION
Motivation
------------
There's an leaking issue when using multiple instances of the library on the same page, where config settings differ (app, user auth etc). The reason is that when the library is required through DI, a singleton is always returned which means multiple SDK instances can't be used on the same page/script.

This PR adds a new method `newInstance` that simply returns a new instance of the SDK class.

Design choices
------------
Instead of changing the default `module.export` behaviour and thus breaking backwards compatibility, we just added a new optional method that can be used instead.

Tests
------------
Added one test.


Related dependencies
------------
https://github.com/timekit-io/booking-js/pull/152

Who should review it
------------
@Trolzie 