### PR TITLE
Carry payload helper method

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "axios": "^0.12.0",
     "base-64": "^0.1.0",
+    "deepmerge": "^1.5.2",
     "es6-promise-promise": "^1.0.0",
     "humps": "^0.7.0"
   }

--- a/test/configuration.spec.js
+++ b/test/configuration.spec.js
@@ -481,7 +481,7 @@ describe('Configuration', function() {
     })
   });
 
-  fit('should support carrying payload data for next only (fluent), merging query params', function(done) {
+  it('should support carrying payload data for next only (fluent), merging query params', function(done) {
     var request;
 
     timekit.configure({

--- a/test/configuration.spec.js
+++ b/test/configuration.spec.js
@@ -399,4 +399,122 @@ describe('Configuration', function() {
 
   });
 
+  it('should support carrying payload data for next only (fluent), query param', function(done) {
+    var request;
+
+    timekit.configure({
+      app: fixtures.app,
+      apiBaseUrl: fixtures.apiBaseUrl
+    });
+
+    timekit.setUser(fixtures.userEmail, fixtures.userApiToken);
+
+    timekit
+    .carry({
+      params: {
+        q: 'something'
+      }
+    })
+    .getUserInfo()
+
+    utils.tick(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      expect(request.url).toBe(fixtures.apiBaseUrl + 'v2/users/me?q=something')
+
+      timekit
+      .getUserInfo()
+
+      utils.tick(function () {
+        request = jasmine.Ajax.requests.mostRecent();
+
+        expect(request.url).toBe(fixtures.apiBaseUrl + 'v2/users/me')
+
+        done();
+      })
+    })
+  });
+
+  it('should support carrying payload data for next only (fluent), body param', function(done) {
+    var request;
+
+    timekit.configure({
+      app: fixtures.app,
+      apiBaseUrl: fixtures.apiBaseUrl
+    });
+
+    timekit.setUser(fixtures.userEmail, fixtures.userApiToken);
+
+    timekit
+    .carry({
+      data: {
+        last_name: 'doe'
+      }
+    })
+    .updateUser({
+      first_name: 'john'
+    })
+
+    utils.tick(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      var bodyData = request.data()
+
+      expect(bodyData.first_name).toBe('john')
+      expect(bodyData.last_name).toBe('doe')
+
+      timekit
+      .updateUser({
+        first_name: 'peter'
+      })
+
+      utils.tick(function () {
+        request = jasmine.Ajax.requests.mostRecent();
+
+        var bodyData = request.data()
+
+        expect(bodyData.first_name).toBe('peter')
+        expect(bodyData.last_name).toBeUndefined()
+
+        done();
+      })
+    })
+  });
+
+  fit('should support carrying payload data for next only (fluent), merging query params', function(done) {
+    var request;
+
+    timekit.configure({
+      app: fixtures.app,
+      apiBaseUrl: fixtures.apiBaseUrl
+    });
+
+    timekit.setUser(fixtures.userEmail, fixtures.userApiToken);
+
+    timekit
+    .carry({
+      params: {
+        q: 'bar',
+        z: 'bar'
+      }
+    })
+    .makeRequest({
+      method: 'get',
+      url: '/somewhere',
+      params: {
+        q: 'foo',
+        x: 'foo'
+      }
+    })
+
+    utils.tick(function () {
+      request = jasmine.Ajax.requests.mostRecent();
+
+      var resultQuery = 'v2/somewhere?q=foo%3Bbar&z=bar&x=foo'
+      expect(request.url).toBe(fixtures.apiBaseUrl + resultQuery)
+
+      done();
+    })
+  });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,10 @@ deep-is@~0.1.2, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
 delayed-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"


### PR DESCRIPTION
Motivation
------------
A prerequisite for the new app token/global API keys project.

This essentially adds a new method, `.carry()` that allows you to carry/pass/inject payload data to the next request in line. That brings more flexibility into chaining SDK commands together and interpolating additional data into the existing methods without changing their arguments. 

It very much follows the same idea of the existing `.headers()`, `.asApp()` and `.asUser()` methods.

Example usage:
```
timekit
  .carry({
    params: {
      search: 'resource.id:123'
    }
  })
  .getCalendars()
  .then(response => {
    console.log('Query string parameter was added to request')
  })
```

Tests
------------
Made 2 tests for, one for body data and another for query string params.

Who should review it
------------
@Trolzie 