### PR TITLE
Added configurable header

### DIFF
--- a/src/timekit.js
+++ b/src/timekit.js
@@ -108,6 +108,9 @@ function Timekit() {
     // add http headers if applicable
     args.headers = args.headers || headers || {};
 
+    if (config.headers) {
+      args.headers = merge(config.headers, args.headers)
+    }
     if (!args.headers['Timekit-App'] && config.app) {
       args.headers['Timekit-App'] = config.app;
     }


### PR DESCRIPTION
In order for us to be able to better track where requests are coming from, we have added a configurable header. This will give us a better overview for all incoming requests, so we can diagnose issues faster, and understand our API traffic better.

@laander to review