### PR TITLE
Support for app key auth

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+Motivation
+------------
+
+
+Design choices
+------------
+
+
+Side-effects/other
+------------
+
+
+Tests
+------------
+
+
+Known issues/limitations
+------------
+
+
+Release dependencies
+------------
+
+
+Who should review it
+------------

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 node_modules
 test/coverage
 .env
-.yarn-error.log
+yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 test/coverage
 .env
+.yarn-error.log

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Make API calls to Timekit with our easy-to-use JavaScript SDK. It supports all o
 Visit [timekit.io](http://timekit.io) to learn more and don't hesitate to contact Lasse Boisen Andersen ([la@timekit.io](mailto:la@timekit.io) or create an Issue) for questions. PR's are more than welcome!
 
 Features:
-- Returns ES-6/A+ style promises
+- Supports API auth with both app keys and resource keys
+- Returns ES6/A+ style promises
 - Works in both node.js and in the browser (>=IE8 and evergreen)
 - Supports custom timestamp formats and timezones
 
@@ -34,6 +35,11 @@ The SDK is UMD (Universal Module Definition) compatible, which means that it can
 
 *Note: Use plain or minified builds in `/dist` when using in browser. In node, `/src/timekit.js` will be used through npm (or reference it manually in your require)*
 
+**ES6 module**  
+```javascript
+import timekit from 'timekit-sdk'
+console.log(timekit);
+```
 
 **AMD (with e.g. require.js)**  
 ```javascript
@@ -58,6 +64,38 @@ console.log(timekit);
 
 See `/examples` for implementation examples.
 
+## Authentication
+
+### App key
+*Only for server-side integrations!*  
+
+With app keys, your capabilities are scoped on an app-level which mean that you can access data (e.g. bookings) across all resources. It's essential that you only use this for server-side integrations as the key grants full access to your whole timekit app data.
+
+```javascript
+timekit.configure({
+  appKey: 'live_api_key_4cY2KWMggw95mAdx51eYUO2CyIWI2xup'
+})
+```
+
+Your app key can be found in the Timekit admin panel (https://admin.timekit.io)
+
+### Resource keys
+*For client-side integrations!*  
+
+Resource keys are scoped by the resource and the data that they have access to. The primary use-case is together with our booking.js widget that only acts as a single resource at a time.
+
+Resource keys needs to be accompanied by the resource's email and the app attribute. Note that two types of keys exist: `server-token` and `client-token`, where only the latter should be used. Please refer to the [API reference](https://developers.timekit.io/reference#credentials).
+
+```javascript
+timekit.configure({
+  app: 'back-to-the-future',
+  resourceEmail: 'marty.mcfly@timekit.io',
+  resourceKey: '4cY2KWMggw95mAdx51eYUO2CyIWI2xup'
+})
+```
+
+🚨 **Important!** Resource keys are being phased out as a supported authentication mechanism. We encourage you to use app keys for new Timekit integrations.
+
 ## Usage (init)
 The only required configuration is that you set the "app" key to your registered app slug on Timekit.
 
@@ -66,7 +104,6 @@ Here's all the available options:
 ```javascript
 // Overwrites default config with supplied object, possible keys with default values below
 timekit.configure({
-    app:                        'back-to-the-future',       // your registered app name (visit timekit.io)
     apiBaseUrl:                 'https://api.timekit.io/',  // API endpoint (do not change)
     apiVersion:                 'v2',                       // version of API to call (do not change)
     inputTimestampFormat:       'Y-m-d h:ia',               // default timestamp format that you supply
@@ -79,15 +116,6 @@ timekit.configure({
 
 // Returns current config object
 timekit.getConfig();
-
-// Set the user to auth with (gets automatically set after timekit.auth())
-timekit.setUser(
-    email,      // [String] email of the user
-    apiToken    // [String] access token retrieved from API
-);
-
-// Returns current user that have been set previously (email and apiToken)
-timekit.getUser();
 ```
 
 ## Usage (endpoints)
@@ -200,7 +228,7 @@ Response example:
 }
 ```
 
-## Usage (lowlevel API)
+## Usage (low-level API)
 
 If you, for some reason, would like direct access to axios's request API, you can call the `timekit.makeRequest()` method directly. We'll still set the correct config headers, base url and includes, but otherwise it supports all the settings that [axios](https://github.com/mzabriskie/axios) does.
 
@@ -221,22 +249,39 @@ timekit.makeRequest({
 });
 ```
 
-## Dynamic includes
+## Usage (carry)
+
+If you want to inject specific params/query string or data into the next API request, you can use the `carry` method. It's handy for e.g. filtering result (`search`) or adding pagination (`limit`).
+
+Example:
+```javascript
+timekit
+  .carry({
+    params: {
+      search: 'graph:confirm_decline',
+      limit: 10
+    }
+  })
+  .getBookings()
+  .then(function(response) {
+    // Response is filtered by the search query and limited to only 10 items
+  });
+```
+
+## Usage (dynamic includes)
 
 The Timekit API have support for [dynamically including related models](http://developers.timekit.io/docs/dynamic-includes) (aka. expand objects). We supports this functionality by providing a chainable/fluent method called `.include()` that can be called right before a request.
 
 The method takes unlimited string arguments, with each one being a model that you want included in the response. For nested data (e.g. events grouped by calendar), use the dot notation to dig into relations, like `calender.events`.
 
 Example:
-
 ```javascript
-
 timekit
-.include('calendars.events', 'users')
-.getUserInfo()
-.then(function(response) {
+  .include('calendars.events', 'users')
+  .getUserInfo()
+  .then(function(response) {
     // Response contains JSON data with nested info on the user's calendars, events and meetings
-});
+  });
 ```
 
 This is super powerful because it means that you can avoid unnecessary extra requests compared to fetching each resource sequentially.
@@ -270,4 +315,3 @@ karma start
 ## Roadmap/todos
 
 See [Issues](https://github.com/timekit-io/js-sdk/issues) for feature requests, bugs etc.
- 

--- a/src/timekit.js
+++ b/src/timekit.js
@@ -34,9 +34,9 @@ function Timekit() {
     convertResponseToCamelcase: false,
     convertRequestToSnakecase: true,
     autoFlattenResponse: true,
-    userEmail: null,
-    userToken: null,
-    appToken: null,
+    resourceEmail: null,
+    resourceKey: null,
+    appKey: null,
   };
 
   /**
@@ -126,13 +126,13 @@ function Timekit() {
     }
 
     // add auth headers (personal token) if not being overwritten by request/asUser
-    if (!args.headers['Authorization'] && config.userEmail && config.userToken) {
-      args.headers['Authorization'] = 'Basic ' + encodeAuthHeader(config.userEmail, config.userToken);
+    if (!args.headers['Authorization'] && config.resourceEmail && config.resourceKey) {
+      args.headers['Authorization'] = 'Basic ' + encodeAuthHeader(config.resourceEmail, config.resourceKey);
     }
 
     // add auth headers (app token)
-    if (!args.headers['Authorization'] && config.appToken) {
-      args.headers['Authorization'] = 'Basic ' + encodeAuthHeader('', config.appToken);
+    if (!args.headers['Authorization'] && config.appKey) {
+      args.headers['Authorization'] = 'Basic ' + encodeAuthHeader('', config.appKey);
     }
 
     // reset headers
@@ -198,17 +198,9 @@ function Timekit() {
    * Set the active user manually (happens automatically on timekit.auth())
    * @type {Function}
    */
-  TK.setUser = function(email, apiToken) {
-    config.userEmail = email;
-    config.userToken = apiToken;
-  };
-
-  /**
-   * Set app token (happens automatically on timekit.auth())
-   * @type {Function}
-   */
-  TK.setAppToken = function(apiToken) {
-    config.appToken = apiToken;
+  TK.setUser = function(email, apiKey) {
+    config.resourceEmail = email;
+    config.resourceKey = apiKey;
   };
 
   /**
@@ -218,9 +210,17 @@ function Timekit() {
    */
   TK.getUser = function() {
     return {
-      email: config.userEmail,
-      apiToken: config.userToken
+      email: config.resourceEmail,
+      apiToken: config.resourceKey
     };
+  };
+
+  /**
+   * Set app token (happens automatically on timekit.auth())
+   * @type {Function}
+   */
+  TK.setAppKey = function(apiKey) {
+    config.appKey = apiKey;
   };
 
   /**
@@ -228,16 +228,16 @@ function Timekit() {
    * @type {Function}
    * @return {Object}
    */
-  TK.getAppToken = function() {
-    return config.appToken
+  TK.getAppKey = function() {
+    return config.appKey
   };
 
   /**
    * Set the active user temporarily for the next request (fluent/chainable return)
    * @type {Function}
    */
-  TK.asUser = function(email, apiToken) {
-    headers['Authorization'] = 'Basic ' + encodeAuthHeader(email, apiToken);
+  TK.asUser = function(email, apiKey) {
+    headers['Authorization'] = 'Basic ' + encodeAuthHeader(email, apiKey);
     return this;
   };
 

--- a/test/configuration.spec.js
+++ b/test/configuration.spec.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var timekit = require('../src/timekit.js');
+var timekitSdk = require('../src/timekit.js');
 var utils = require('./helpers/utils');
 var base64 = require('base-64');
 
+var timekit = {}
 var fixtures = {
   app:              'demo',
   app2:             'demo2',
@@ -30,6 +31,7 @@ var fixtures = {
 describe('Configuration', function() {
 
   beforeEach(function() {
+    timekit = timekitSdk.newInstance()
     jasmine.Ajax.install();
   });
 

--- a/test/dynamicincludes.spec.js
+++ b/test/dynamicincludes.spec.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var moment = require('moment');
-var timekit = require('../src/timekit.js');
+var timekitSdk = require('../src/timekit.js');
 var utils = require('./helpers/utils');
 
+var timekit = {}
 var fixtures = {
   app:            'timebird',
   apiBaseUrl:     'http://api-localhost.timekit.io/',
@@ -19,6 +20,7 @@ var fixtures = {
 describe('Dynamic includes', function() {
 
   beforeEach(function() {
+    timekit = timekitSdk.newInstance()
     jasmine.Ajax.install();
 
     timekit.configure({

--- a/test/endpoints.spec.js
+++ b/test/endpoints.spec.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var moment = require('moment');
-var timekit = require('../src/timekit.js');
+var timekitSdk = require('../src/timekit.js');
 var utils = require('./helpers/utils');
 
+var timekit = {}
 var fixtures = {
   app:            'demo',
   apiBaseUrl:     'http://api-localhost.timekit.io/',
@@ -18,10 +19,17 @@ var fixtures = {
  */
 describe('Endpoints', function() {
 
+  beforeEach(function() {
+    timekit = timekitSdk.newInstance()
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
   it('should be able to call an endpoint through a method', function(done) {
     var request, response;
-
-    jasmine.Ajax.install();
 
     timekit.configure({
       app: fixtures.app,
@@ -50,7 +58,6 @@ describe('Endpoints', function() {
       utils.tick(function () {
         expect(response.data).toBeDefined();
         expect(Object.prototype.toString.call(response.data)).toBe('[object Array]');
-        jasmine.Ajax.uninstall();
         done();
       });
     });


### PR DESCRIPTION
Motivation
------------
After releasing app key based authentication, the JS SDK never got updated to explicitly supporting it. This PR adds app key auth and updates the Readme with more up to date examples.

Design choices
------------
You can supply `appKey` into the `timekit.configure()` method. Or use the `timekit.setAppKey()` method to set/update it later.

Side-effects/other
------------
When App Widget Key is officially released, the Readme should be updated to reflect that.

Tests
------------
Made a test that check the request headers are set correctly.

Who should review it
------------
@vistik 