### PR TITLE
Added option to send `include` query string with getBookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ timekit.findTimeTeam({ ... })
 timekit.fetchAvailability({ ... })
 
 // Booking endpoints
-timekit.getBookings()
+timekit.getBookings([ include ])
 timekit.getBooking({ id })
 timekit.createBooking({ ... })
 timekit.createBookingsBulk({ ... })

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -510,10 +510,15 @@ module.exports = function (TK) {
    * @type {Function}
    * @return {Promise}
    */
-  TK.getBookings = function() {
+  TK.getBookings = function(data) {
+    var queryString = '';
+
+    if (Array.isArray(data)) {
+      queryString = '?include='+data.join(','),
+    }
 
     return TK.makeRequest({
-      url: '/bookings',
+      url: '/bookings'+queryString,
       method: 'get'
     });
 


### PR DESCRIPTION
Motivation
------------
I wanted a way to send the `include` query string to the getBookings endpoint without having to use a big carry function each time.

Design choices
------------
I chose to have the user pass in an array, despite the fact that the other endpoints use an object, because it seemed cleaner to do : 
`getBooking(['available_actions','attributes','calendar','customers'])`
than
`getBooking({include:['available_actions','attributes','calendar','customers']})`
or
```
getBooking({
  include: {
    calendar: true,
    available_actions: true,
    etc: true,
  }
})
```
Side-effects/other
------------
There is now the potential for users to get an error if they pass invalid options to getBooking.
e.g.
`getBooking(['foo'])` generates the query string of `?include=foo` which the timekit api will respond to with: `status: 422, statusText: 'Unprocessable Entity'`

If that's a deal breaker I'm happy to include a check to only pass valid includes.

Tests
------------
No new tests needed

Known issues/limitations
------------
only above potential for error message

Release dependencies
------------
n/a

Who should review it
------------
whomever is available